### PR TITLE
use @bpanel/curl plugin as  proxy endpoint for all APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   parser: 'babel-eslint',
   plugins: ['prettier', 'react'],
   env: {
+    browser: true,
     node: true,
     es6: true
   },

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { Client } from 'bcurl';
 
 // determine the port and ssl usage
@@ -61,8 +63,7 @@ export const feeds = {
 
   Blockchain_info: {
     getPrice: async ({ fiat, crypto }) => {
-      if (crypto !== 'BTC')
-        return 0;
+      if (crypto !== 'BTC') return 0;
       const path = 'ticker';
       const url = {
         host: 'blockchain.info',
@@ -87,8 +88,7 @@ export const feeds = {
 
   Bitfinex: {
     getPrice: async ({ fiat, crypto }) => {
-      if (crypto !== 'BTC')
-        return 0;
+      if (crypto !== 'BTC') return 0;
       const path = 'v1/pubticker/' + crypto + fiat;
       const url = {
         host: 'api.bitfinex.com',

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -4,7 +4,12 @@ const curlClient = new bcurlClient();
 
 async function curl(url) {
   const uriPath = encodeURIComponent(url.path);
-  return curlClient.get('/' + url.host + '/' + uriPath);
+  try {
+    return await curlClient.get('/' + url.host + '/' + uriPath);
+  } catch (e) {
+    console.log('Error fetching JSON API: ', e);
+    return {};
+  }
 }
 
 /*
@@ -63,6 +68,63 @@ export const feeds = {
       const result = await curl(url);
       const fiats = Object.keys(result);
       return fiats;
+    }
+  },
+
+  Bitfinex: {
+    getPrice: async ({ fiat, crypto }) => {
+      if (crypto !== 'BTC')
+        return 0;
+      const path = 'v1/pubticker/' + crypto + fiat;
+      const url = {
+        host: 'api.bitfinex.com',
+        path: path
+      };
+      const result = await curl(url);
+      return result.last_price;
+    },
+
+    getFiats: async () => {
+      return Promise.resolve(['USD', 'EUR', 'GBP', 'JPY']);
+    }
+  },
+
+  Bitstamp: {
+    getPrice: async ({ fiat, crypto }) => {
+      const path = 'api/v2/ticker/' + crypto + fiat;
+      const url = {
+        host: 'www.bitstamp.net',
+        path: path
+      };
+      const result = await curl(url);
+      return result.last;
+    },
+
+    getFiats: async () => {
+      return Promise.resolve(['USD', 'EUR']);
+    }
+  },
+
+  Kraken: {
+    getPrice: async ({ fiat, crypto }) => {
+      // seriously!? Ok...
+      crypto = crypto === 'BTC' ? 'XBT' : crypto;
+
+      const path = '0/public/Ticker?pair=' + crypto + fiat;
+      const url = {
+        host: 'api.kraken.com',
+        path: path
+      };
+      const response = await curl(url);
+      const result = response.result;
+      // Ah geez REALLY?
+      const randomUselessString = Object.keys(result)[0];
+      const actualUsefulInfo = result[randomUselessString];
+      return actualUsefulInfo.c[0];
+    },
+
+    getFiats: async () => {
+      return Promise.resolve(['USD', 'EUR', 'CAD', 'JPY']);
     }
   }
 };

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -1,11 +1,25 @@
-import { bcurlClient } from '@bpanel/bpanel-utils';
+import { Client } from 'bcurl';
 
-const curlClient = new bcurlClient();
+// determine the port and ssl usage
+const protocol = window.location.protocol;
+const hostname = window.location.hostname;
+let port = window.location.port;
+let ssl = false;
+// use https and http ports when the window doesn't render them
+if (port === '') protocol === 'https:' ? (port = '443') : (port = '80');
+if (protocol === 'https:') ssl = true;
+
+const curlClient = new Client({
+  port: parseInt(port, 10),
+  path: '/curl/',
+  host: hostname,
+  ssl
+});
 
 async function curl(url) {
   const uriPath = encodeURIComponent(url.path);
   try {
-    return await curlClient.get('/' + url.host + '/' + uriPath);
+    return await curlClient.get(url.host + '/' + uriPath);
   } catch (e) {
     console.log('Error fetching JSON API: ', e);
     return {};

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -1,20 +1,10 @@
-const https = require('https');
+import { bcurlClient } from '@bpanel/bpanel-utils';
 
-function httpsGet(options) {
-  return new Promise((resolve, reject) => {
-    https.get(options, (resp) => {
-      // https.get API streams data
-      let data = '';
-      resp.on('data', (chunk) => {
-        data += chunk;
-      });
-      resp.on('end', () => {
-        resolve(JSON.parse(data));
-      });
-    }).on('error', (err) => {
-      reject('Error: ' + err.message);
-    });
-  });
+const curlClient = new bcurlClient();
+
+async function curl(url) {
+  const uriPath = encodeURIComponent(url.path);
+  return curlClient.get('/' + url.host + '/' + uriPath);
 }
 
 /*
@@ -27,21 +17,21 @@ function httpsGet(options) {
 export const feeds = {
   Coinbase: {
     getPrice: async ({ fiat, crypto }) => {
-      const path = '/products/' + crypto + '-' + fiat + '/ticker';
-      const options = {
-        hostname: 'api.pro.coinbase.com',
+      const path = 'products/' + crypto + '-' + fiat + '/ticker';
+      const url = {
+        host: 'api.pro.coinbase.com',
         path: path
       };
-      const result = await httpsGet(options);
+      const result = await curl(url);
       return result.price;
     },
 
     getFiats: async () => {
-      const options = {
-        hostname: 'api.pro.coinbase.com',
-        path: '/currencies'
+      const url = {
+        host: 'api.pro.coinbase.com',
+        path: 'currencies'
       };
-      const result = await httpsGet(options);
+      const result = await curl(url);
       let fiats = [];
       for (const item of result) {
         if (item.details.type === 'fiat') fiats.push(item.id);
@@ -52,25 +42,25 @@ export const feeds = {
 
   Blockchain_info: {
     getPrice: async ({ fiat, crypto }) => {
-      if (crypto !==  'BTC')
+      if (crypto !== 'BTC')
         return 0;
-      const path = '/ticker';
-      const options = {
-        hostname: 'blockchain.info',
+      const path = 'ticker';
+      const url = {
+        host: 'blockchain.info',
         path: path
       };
-      const result = await httpsGet(options);
+      const result = await curl(url);
       const price = result[fiat].last;
       return price;
     },
 
     getFiats: async () => {
-      const path = '/ticker';
-      const options = {
-        hostname: 'blockchain.info',
+      const path = 'ticker';
+      const url = {
+        host: 'blockchain.info',
         path: path
       };
-      const result = await httpsGet(options);
+      const result = await curl(url);
       const fiats = Object.keys(result);
       return fiats;
     }

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -126,5 +126,21 @@ export const feeds = {
     getFiats: async () => {
       return Promise.resolve(['USD', 'EUR', 'CAD', 'JPY']);
     }
+  },
+
+  Cex_io: {
+    getPrice: async ({ fiat, crypto }) => {
+      const path = 'api/ticker/' + crypto + '/' + fiat;
+      const url = {
+        host: 'cex.io',
+        path: path
+      };
+      const result = await curl(url);
+      return result.last;
+    },
+
+    getFiats: async () => {
+      return Promise.resolve(['USD', 'EUR', 'GBP', 'RUB']);
+    }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const { CURRENCY_UNITS } = require('@bpanel/bpanel-utils');
 import { feeds } from './feeds';
+//import * as bpanel_curl from 'bpanel-curl';
 
 /* Constants */
 
@@ -122,6 +123,10 @@ export const metadata = {
   description: 'Fetch BTC-fiat exchange rate and add to app store.',
   version: require('../package.json').version
 };
+
+//export const pluginConfig = {
+//  plugins: [bpanel_curl]
+//};
 
 export const pluginReducers = {
   price: priceReducer

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,10 +113,10 @@ const updateFiat = fiat => ({
   payload: fiat
 });
 
-const refreshPrice = {
+const refreshPrice = () => ({
   type: 'REFRESH_PRICE',
   payload: {}
-};
+});
 
 /* Exports */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-console */
+
 /* Imports */
 
 const { CURRENCY_UNITS } = require('@bpanel/bpanel-utils');
 import { feeds } from './feeds';
-//import * as bpanel_curl from 'bpanel-curl';
 
 /* Constants */
 
@@ -50,7 +51,7 @@ function priceReducer(state = initState, action) {
   const newState = { ...state };
 
   switch (action.type) {
-    case 'UPDATE_PRICE':
+    case 'UPDATE_PRICE': {
       let newPrice = action.payload;
       if (!isFloat(newPrice)) {
         newPrice = 0;
@@ -58,25 +59,30 @@ function priceReducer(state = initState, action) {
       }
       newState.price = newPrice;
       return newState;
-    case 'UPDATE_FIAT':
+    }
+    case 'UPDATE_FIAT': {
       const newFiat = action.payload;
       if (!state.availableFiats.includes(newFiat))
         throw new Error('Selected fiat currency is not available');
       newState.fiat = newFiat;
       newState.fiatSymbol = fiatSymbols[action.payload] || '';
       return newState;
-    case 'UPDATE_CRYPTO':
+    }
+    case 'UPDATE_CRYPTO': {
       newState.crypto = action.payload;
       return newState;
-    case 'SET_FEED':
+    }
+    case 'SET_FEED': {
       const newFeed = action.payload;
       if (!state.availableFeeds.includes(newFeed))
         throw new Error('Selected API feed is not available');
       newState.feed = newFeed;
       return newState;
-    case 'UPDATE_AVAIL_FIATS':
+    }
+    case 'UPDATE_AVAIL_FIATS': {
       newState.availableFiats = action.payload;
       return newState;
+    }
     default:
       return state;
   }
@@ -107,11 +113,10 @@ const updateFiat = fiat => ({
   payload: fiat
 });
 
-const refreshPrice = fiat => ({
+const refreshPrice = {
   type: 'REFRESH_PRICE',
   payload: {}
-});
-
+};
 
 /* Exports */
 
@@ -123,10 +128,6 @@ export const metadata = {
   description: 'Fetch BTC-fiat exchange rate and add to app store.',
   version: require('../package.json').version
 };
-
-//export const pluginConfig = {
-//  plugins: [bpanel_curl]
-//};
 
 export const pluginReducers = {
   price: priceReducer
@@ -140,7 +141,7 @@ export const middleware = store => next => async action => {
   let price;
 
   switch (action.type) {
-    case 'STATE_REFRESHED':
+    case 'STATE_REFRESHED': {
       // Get current chain and update to new crypto
       const chain = getState().clients.currentClient.chain;
       const ticker = getTickerFromChain(chain);
@@ -153,27 +154,29 @@ export const middleware = store => next => async action => {
         price = await newFeed.getPrice(newPriceState);
         dispatch(updatePrice(price));
       } catch (e) {
-        console.log("Error updating price: ", e);
+        console.log('Error updating price: ', e);
         dispatch(updatePrice(0));
       }
       try {
         const availableFiats = await newFeed.getFiats();
         dispatch(updateAvailFiats(availableFiats));
       } catch (e) {
-        console.log("Error updating fiats: ", e);
+        console.log('Error updating fiats: ', e);
         dispatch(updateAvailFiats([]));
       }
       break;
-    case 'REFRESH_PRICE':
+    }
+    case 'REFRESH_PRICE': {
       try {
         price = await currentFeed.getPrice(priceState);
         dispatch(updatePrice(price));
       } catch (e) {
-        console.log("Error updating price: ", e);
+        console.log('Error updating price: ', e);
         dispatch(updatePrice(0));
       }
       break;
-    case 'UPDATE_FEED':
+    }
+    case 'UPDATE_FEED': {
       dispatch(setFeed(action.payload));
       const feedObject = feeds[action.payload];
       try {
@@ -182,11 +185,12 @@ export const middleware = store => next => async action => {
         if (!availableFiats.includes(currentFiat))
           dispatch(updateFiat(availableFiats[0]));
       } catch (e) {
-        console.log("Error updating fiats: ", e);
+        console.log('Error updating fiats: ', e);
         dispatch(updateAvailFiats([]));
       }
       dispatch(refreshPrice());
       break;
+    }
   }
   return next(action);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,9 +174,8 @@ export const middleware = store => next => async action => {
       }
       break;
     case 'UPDATE_FEED':
-      const newFeed = action.payload;
-      dispatch(setFeed(newFeed));
-      const feedObject = feeds[newFeed];
+      dispatch(setFeed(action.payload));
+      const feedObject = feeds[action.payload];
       try {
         const availableFiats = await feedObject.getFiats();
         dispatch(updateAvailFiats(availableFiats));

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,20 +140,24 @@ export const middleware = store => next => async action => {
   let price;
 
   switch (action.type) {
-    case 'SET_CURRENT_CLIENT':
-      const chain = action.payload.chain;
+    case 'STATE_REFRESHED':
+      // Get current chain and update to new crypto
+      const chain = getState().clients.currentClient.chain;
       const ticker = getTickerFromChain(chain);
       dispatch(updateCrypto(ticker));
+
+      // now that crypto has been updated in state, get price and fiat options
       const newPriceState = getState().plugins.price;
+      const newFeed = feeds[newPriceState.feed];
       try {
-        price = await currentFeed.getPrice(newPriceState);
+        price = await newFeed.getPrice(newPriceState);
         dispatch(updatePrice(price));
       } catch (e) {
         console.log("Error updating price: ", e);
         dispatch(updatePrice(0));
       }
       try {
-        const availableFiats = await currentFeed.getFiats();
+        const availableFiats = await newFeed.getFiats();
         dispatch(updateAvailFiats(availableFiats));
       } catch (e) {
         console.log("Error updating fiats: ", e);

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ function priceReducer(state = initState, action) {
     case 'UPDATE_CRYPTO':
       newState.crypto = action.payload;
       return newState;
-    case 'UPDATE_FEED':
+    case 'SET_FEED':
       const newFeed = action.payload;
       if (!state.availableFeeds.includes(newFeed))
         throw new Error('Selected API feed is not available');
@@ -96,6 +96,22 @@ const updateAvailFiats = fiats => ({
   payload: fiats
 });
 
+const setFeed = feed => ({
+  type: 'SET_FEED',
+  payload: feed
+});
+
+const updateFiat = fiat => ({
+  type: 'UPDATE_FIAT',
+  payload: fiat
+});
+
+const refreshPrice = fiat => ({
+  type: 'REFRESH_PRICE',
+  payload: {}
+});
+
+
 /* Exports */
 
 export const metadata = {
@@ -113,21 +129,55 @@ export const pluginReducers = {
 
 export const middleware = store => next => async action => {
   const { dispatch, getState } = store;
+  const priceState = getState().plugins.price;
+  const currentFeed = feeds[priceState.feed];
+  const currentFiat = priceState.fiat;
+  let price;
 
   switch (action.type) {
     case 'SET_CURRENT_CLIENT':
-    case 'REFRESH_PRICE':
-      if (action.type === 'SET_CURRENT_CLIENT') {
-        const chain = action.payload.chain;
-        const ticker = getTickerFromChain(chain);
-        dispatch(updateCrypto(ticker));
+      const chain = action.payload.chain;
+      const ticker = getTickerFromChain(chain);
+      dispatch(updateCrypto(ticker));
+      const newPriceState = getState().plugins.price;
+      try {
+        price = await currentFeed.getPrice(newPriceState);
+        dispatch(updatePrice(price));
+      } catch (e) {
+        console.log("Error updating price: ", e);
+        dispatch(updatePrice(0));
       }
-      const priceState = getState().plugins.price;
-      const feed = feeds[priceState.feed];
-      const price = await feed.getPrice(priceState);
-      const availableFiats = await feed.getFiats();
-      dispatch(updatePrice(price));
-      dispatch(updateAvailFiats(availableFiats));
+      try {
+        const availableFiats = await currentFeed.getFiats();
+        dispatch(updateAvailFiats(availableFiats));
+      } catch (e) {
+        console.log("Error updating fiats: ", e);
+        dispatch(updateAvailFiats([]));
+      }
+      break;
+    case 'REFRESH_PRICE':
+      try {
+        price = await currentFeed.getPrice(priceState);
+        dispatch(updatePrice(price));
+      } catch (e) {
+        console.log("Error updating price: ", e);
+        dispatch(updatePrice(0));
+      }
+      break;
+    case 'UPDATE_FEED':
+      const newFeed = action.payload;
+      dispatch(setFeed(newFeed));
+      const feedObject = feeds[newFeed];
+      try {
+        const availableFiats = await feedObject.getFiats();
+        dispatch(updateAvailFiats(availableFiats));
+        if (!availableFiats.includes(currentFiat))
+          dispatch(updateFiat(availableFiats[0]));
+      } catch (e) {
+        console.log("Error updating fiats: ", e);
+        dispatch(updateAvailFiats([]));
+      }
+      dispatch(refreshPrice());
       break;
   }
   return next(action);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "bcurl": "pinheadmz/bcurl#bpanel-dev",
-    "@bpanel/curl": "^0.0.1"
+    "bcurl": "pinheadmz/bcurl#bpanel-dev"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",
@@ -44,6 +43,7 @@
     "prettier": "^1.11.1"
   },
   "peerDependencies": {
+    "@bpanel/curl": "^0.0.1",
     "@bpanel/bpanel-ui": "^0.0.16",
     "@bpanel/bpanel-utils": "^0.1.4",
     "react": "^16.3.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "bcurl": "^0.1.4"
+    "bcurl": "pinheadmz/bcurl#bpanel-dev",
+    "@bpanel/curl": "^0.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "repository": "git://github.com/bpanel-org/price.git",
   "dependencies": {
     "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0"
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "bcurl": "^0.1.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",


### PR DESCRIPTION
Addresses #1 regarding feeds and using https module.

This makes way more sense, and allows us to add way more price APIs (a few of the bigger ones I checked out don't allow CORS headers and can't be fetched directly by the client)

Requires https://github.com/bpanel-org/bpanel/pull/158 and https://github.com/bpanel-org/bpanel-utils/pull/42