### PR TITLE
set chain when node finished loading

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ const initState = {
   price: 0,
   fiat: 'USD',
   fiatSymbol: '$',
-  crypto: 'BTC',
+  crypto: '',
   feed: Object.keys(feeds)[0],
   availableFeeds: Object.keys(feeds),
   availableFiats: ['USD']
@@ -141,7 +141,12 @@ export const middleware = store => next => async action => {
   let price;
 
   switch (action.type) {
+    case 'SET_LOADING':
     case 'STATE_REFRESHED': {
+      // can skip if node is currently loading
+      // if it's done loading then update feeds
+      if (action.type === 'SET_LOADING' && action.payload) break;
+
       // Get current chain and update to new crypto
       const chain = getState().clients.currentClient.chain;
       const ticker = getTickerFromChain(chain);


### PR DESCRIPTION
Also not defaulting to any crypto in initial state to avoid confusing flashing of a price that may not even be relevant to someone not running any btc nodes.